### PR TITLE
Fix VLAs and header for MSVC

### DIFF
--- a/fec/decode_rs.h
+++ b/fec/decode_rs.h
@@ -21,9 +21,10 @@
  * DEBUG - If set to 1 or more, do various internal consistency checking. Leave this
  *         undefined for production code
 
- * The memset(), memmove(), and memcpy() functions are used. The appropriate header
- * file declaring these functions (usually <string.h>) must be included by the calling
- * program.
+ * The memset(), memmove(), and memcpy() functions are used.  The appropriate
+ * header file declaring these functions (usually <string.h>) must be included
+ * by the calling program.  Dynamic allocation is performed with calloc() and
+ * free(), so <stdlib.h> must also be included.
  */
 
 
@@ -70,13 +71,21 @@
 
 {
   int deg_lambda, el, deg_omega;
-  int i, j, r,k;
-  data_t u,q,tmp,num1,num2,den,discr_r;
-  data_t lambda[NROOTS+1], s[NROOTS];	/* Err+Eras Locator poly
-					 * and syndrome poly */
-  data_t b[NROOTS+1], t[NROOTS+1], omega[NROOTS+1];
-  data_t root[NROOTS], reg[NROOTS+1], loc[NROOTS];
+  int i, j, r, k;
+  data_t u, q, tmp, num1, num2, den, discr_r;
+  data_t *lambda = (data_t *)calloc(NROOTS + 1, sizeof(data_t));
+  data_t *s      = (data_t *)calloc(NROOTS, sizeof(data_t));
+  data_t *b      = (data_t *)calloc(NROOTS + 1, sizeof(data_t));
+  data_t *t      = (data_t *)calloc(NROOTS + 1, sizeof(data_t));
+  data_t *omega  = (data_t *)calloc(NROOTS + 1, sizeof(data_t));
+  data_t *root   = (data_t *)calloc(NROOTS, sizeof(data_t));
+  data_t *reg    = (data_t *)calloc(NROOTS + 1, sizeof(data_t));
+  data_t *loc    = (data_t *)calloc(NROOTS, sizeof(data_t));
   int syn_error, count;
+  if(!lambda || !s || !b || !t || !omega || !root || !reg || !loc){
+    retval = -1;
+    goto cleanup;
+  }
 
   /* form the syndromes; i.e., evaluate data(x) at roots of g(x) */
   for(i=0;i<NROOTS;i++)
@@ -295,4 +304,13 @@
       eras_pos[i] = loc[i];
   }
   retval = count;
+cleanup:
+  free(lambda);
+  free(s);
+  free(b);
+  free(t);
+  free(omega);
+  free(root);
+  free(reg);
+  free(loc);
 }

--- a/fec/decode_rs_char.c
+++ b/fec/decode_rs_char.c
@@ -8,6 +8,7 @@
 #endif
 
 #include <string.h>
+#include <stdlib.h>
 
 #include "char.h"
 #include "rs-common.h"
@@ -15,8 +16,22 @@
 int decode_rs_char(void *p, data_t *data, int *eras_pos, int no_eras){
   int retval;
   struct rs *rs = (struct rs *)p;
- 
+
 #include "decode_rs.h"
-  
+
+  /* Clean up macros imported from char.h */
+#undef MODNN
+#undef MM
+#undef NN
+#undef ALPHA_TO
+#undef INDEX_OF
+#undef GENPOLY
+#undef NROOTS
+#undef FCR
+#undef PRIM
+#undef IPRIM
+#undef PAD
+#undef A0
+
   return retval;
 }

--- a/fec/init_rs_char.c
+++ b/fec/init_rs_char.c
@@ -8,6 +8,10 @@
 #include "char.h"
 #include "rs-common.h"
 
+/* The macros from char.h remain in scope for init_rs.h, but
+ * they pollute the global namespace afterwards.  We'll
+ * undefine them once we're done including init_rs.h. */
+
 void free_rs_char(void *p){
   struct rs *rs = (struct rs *)p;
 
@@ -30,6 +34,20 @@ void *init_rs_char(int symsize,int gfpoly,int fcr,int prim,
   struct rs *rs;
 
 #include "init_rs.h"
+
+  /* Clean up macros imported from char.h */
+#undef MODNN
+#undef MM
+#undef NN
+#undef ALPHA_TO
+#undef INDEX_OF
+#undef GENPOLY
+#undef NROOTS
+#undef FCR
+#undef PRIM
+#undef IPRIM
+#undef PAD
+#undef A0
 
   return rs;
 }


### PR DESCRIPTION
## Summary
- allocate RS decoder working buffers on the heap inside `decode_rs.h`
- restore `decode_rs_char.c` wrapper that includes the refactored header
- undefine FEC macros after use

## Testing
- `make fec_tests`
- `./fec_tests`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_684e5d9877cc832db4ad116e24e72f18